### PR TITLE
add custom_example section and exercise

### DIFF
--- a/03_creating_asdf_files/03_solutions.ipynb
+++ b/03_creating_asdf_files/03_solutions.ipynb
@@ -259,6 +259,49 @@
     "af.write_to(\"astropy_objects.asdf\")\n",
     "print_file(\"astropy_objects.asdf\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c2bfde56-721c-4d6c-9514-9d4c8cf63f66",
+   "metadata": {},
+   "source": [
+    "## Exercise 8\n",
+    "\n",
+    "What happens if you set \"sequence_id\" to a string and call [validate](https://asdf.readthedocs.io/en/latest/api/asdf.AsdfFile.html#asdf.AsdfFile.validate)?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f21540d8-19bb-4d41-8e21-f22c75a9c281",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "schema_contents = \"\"\"%YAML 1.1\n",
+    "---\n",
+    "id: \"http://example.com/schemas/your-custom-schema\"\n",
+    "$schema: \"http://stsci.edu/schemas/yaml-schema/draft-01\"\n",
+    "\n",
+    "type: object\n",
+    "properties:\n",
+    "  image:\n",
+    "    description: My awesome image\n",
+    "\n",
+    "  exposure_id:\n",
+    "    type: integer\n",
+    "    description: Numeric identifier for this image\n",
+    "\n",
+    "required: [image, exposure_id]\"\"\"\n",
+    "\n",
+    "# and write this out to a file so we can use it below\n",
+    "with open(\"image_schema-1.0.0.yaml\", \"w\") as f:\n",
+    "    f.write(schema_contents)\n",
+    "\n",
+    "af = asdf.AsdfFile(custom_schema=\"image_schema-1.0.0.yaml\")\n",
+    "af[\"image\"] = [1, 2, 3]\n",
+    "af[\"exposure_id\"] = \"not_a_number\"\n",
+    "af.validate()"
+   ]
   }
  ],
  "metadata": {

--- a/03_creating_asdf_files/Creating ASDF Files.ipynb
+++ b/03_creating_asdf_files/Creating ASDF Files.ipynb
@@ -492,6 +492,58 @@
     "    \n",
     "4. A [ICRS](https://docs.astropy.org/en/stable/api/astropy.coordinates.ICRS.html) coordinate object."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fdc5fc4c-907b-447e-bd2c-bc4e1d7f754e",
+   "metadata": {},
+   "source": [
+    "# ✅ ASDF schemas\n",
+    "ASDF files are validated using [JSON Schema](https://json-schema.org/specification-links#draft-4). Custom objects (like [NDArrayType](https://asdf.readthedocs.io/en/latest/api/asdf.tags.core.NDArrayType.html)) have schemas (like [ndarray-1.0.0](https://github.com/asdf-format/asdf-standard/blob/main/resources/schemas/stsci.edu/asdf/core/ndarray-1.0.0.yaml)) that define file content requirements. These are useful when writing ASDF extensions as the schemas describe what feature are required of an asdf implementation (we won't go into details about shcemas and extensions here but please see the [documentation](https://asdf.readthedocs.io/en/latest/asdf/extending/schemas.html) for more information).\n",
+    "For this workshop we'll use a different feature available using schemas, the ability to define the structure of a file using a custom schema. Let's start by defining a basic schema for an \"image\" with a numeric \"sequence_id\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "43efbf98-cce8-4011-9229-62e8ca2d599d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "schema_contents = \"\"\"%YAML 1.1\n",
+    "---\n",
+    "id: \"http://example.com/schemas/your-custom-schema\"\n",
+    "$schema: \"http://stsci.edu/schemas/yaml-schema/draft-01\"\n",
+    "\n",
+    "type: object\n",
+    "properties:\n",
+    "  image:\n",
+    "    description: My awesome image\n",
+    "\n",
+    "  exposure_id:\n",
+    "    type: integer\n",
+    "    description: Numeric identifier for this image\n",
+    "\n",
+    "required: [image, exposure_id]\"\"\"\n",
+    "\n",
+    "# and write this out to a file so we can use it below\n",
+    "with open(\"image_schema-1.0.0.yaml\", \"w\") as f:\n",
+    "    f.write(schema_contents)\n",
+    "\n",
+    "af = asdf.AsdfFile(custom_schema=\"image_schema-1.0.0.yaml\")\n",
+    "af[\"image\"] = [1, 2, 3]\n",
+    "af[\"exposure_id\"] = 42\n",
+    "af.validate()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3fbb5d72-1dad-4a03-83bb-d9cd5b126c17",
+   "metadata": {},
+   "source": [
+    "# Exercise 8: Schema validation\n",
+    "What happens if you set \"sequence_id\" to a string and call [validate](https://asdf.readthedocs.io/en/latest/api/asdf.AsdfFile.html#asdf.AsdfFile.validate)?"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
I'll open this PR for review but at the moment I don't think encouraging `custom_schema` use is a good thing. It doesn't behave as I would expect. Here are a few issues (that will become asdf issues):
- providing a `custom_schema` on `AsdfFile.__init__` doesn't cause a validation error when `write_to` is called: https://github.com/asdf-format/asdf/issues/1860
- asdf caches schemas and appears to cache based on file name (or something), this can lead to unexpected behavior if a schema file is change within an interactive session https://github.com/asdf-format/asdf/issues/1861